### PR TITLE
Spring IO platform will reach the end of its supported life on 9 Apri…

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-integration-tests</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
 
@@ -18,23 +18,25 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-spells</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-processor</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.5</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -46,6 +48,15 @@
             <artifactId>junit</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.testing.compile</groupId>
@@ -66,9 +77,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.spring.platform</groupId>
-                <artifactId>platform-bom</artifactId>
-                <version>Brussels-SR1</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.0.3.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-integration-tests</artifactId>
-    <version>2.4.5</version>
+    <version>2.4.6</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
 
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-processor</artifactId>
-            <version>2.4.5</version>
+            <version>2.4.6</version>
             <scope>provided</scope>
         </dependency>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-spells</artifactId>
-            <version>2.4.5</version>
+            <version>2.4.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-parent</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-parent</artifactId>
-    <version>2.4.5</version>
+    <version>2.4.6</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-processor</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
     <properties>
@@ -24,16 +24,18 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-spells</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -66,13 +68,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.3.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-            <version>2.0.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -82,7 +77,7 @@
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
-            <version>2.0.6</version>
+            <version>2.1.14</version>
         </dependency>
 
     </dependencies>
@@ -90,9 +85,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.spring.platform</groupId>
-                <artifactId>platform-bom</artifactId>
-                <version>Brussels-SR1</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.0.3.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-processor</artifactId>
-    <version>2.4.5</version>
+    <version>2.4.6</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
     <properties>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-spells</artifactId>
-            <version>2.4.5</version>
+            <version>2.4.6</version>
         </dependency>
 
         <dependency>

--- a/spells/pom.xml
+++ b/spells/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-spells</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
     <properties>
@@ -24,16 +24,18 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-targets</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -73,13 +75,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.3.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-            <version>2.0.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -97,9 +92,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.spring.platform</groupId>
-                <artifactId>platform-bom</artifactId>
-                <version>Brussels-SR1</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.0.3.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spells/pom.xml
+++ b/spells/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-spells</artifactId>
-    <version>2.4.5</version>
+    <version>2.4.6</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
     <properties>

--- a/spells/pom.xml
+++ b/spells/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.codesorcerer</groupId>
             <artifactId>codesorcerer-targets</artifactId>
-            <version>2.4.5</version>
+            <version>2.4.6</version>
         </dependency>
 
         <dependency>

--- a/spells/src/main/java/com/codesorcerer/generators/def/spells/JacksonSpell.java
+++ b/spells/src/main/java/com/codesorcerer/generators/def/spells/JacksonSpell.java
@@ -35,9 +35,9 @@ public class JacksonSpell extends AbstractJavaBeanSpell<BBBJson> {
                 .build());
 
         classBuilder.addAnnotation(AnnotationSpec.builder(JsonTypeInfo.class)
-                .addMember("use", "$T.Id.CLASS", JsonTypeInfo.class)
+                .addMember("use", "$T.Id.MINIMAL_CLASS", JsonTypeInfo.class)
                 .addMember("include", "$T.As.PROPERTY", JsonTypeInfo.class)
-                .addMember("property", "\"clazz\"")
+                .addMember("property", "\"className\"")
                 .build());
     }
 

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-targets</artifactId>
-    <version>2.4.5</version>
+    <version>2.4.6</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
     <properties>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.codesorcerer</groupId>
     <artifactId>codesorcerer-targets</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
     <name>${project.groupId}.${project.artifactId}</name>
 
     <properties>
@@ -18,10 +18,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
         </dependency>
 
         <dependency>
@@ -36,19 +38,14 @@
             <version>2.1.8</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.spring.platform</groupId>
-                <artifactId>platform-bom</artifactId>
-                <version>Brussels-SR1</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.0.3.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Spring IO platform will reach the end of its supported life on 9 April 2019(https://spring.io/projects/platform). Update to use spring-boot-dependencies bom.

Also current version in uxp-shared is 2.4.4, however it is 2.4.3 in the forked head. I am not sure whether there is anything missing between those two versions. 

